### PR TITLE
fix regexp

### DIFF
--- a/rabbitmq/detect_rabbitmq_nodes.sh
+++ b/rabbitmq/detect_rabbitmq_nodes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-LIST_NODES=$(sudo /usr/sbin/rabbitmqctl cluster_status|sed -n '3p'| sed -n '/running_nodes,\[.*\]\},/p' | sed  -r 's/\[|\]|\{|\}|running_nodes,//g')
+LIST_NODES=$(sudo /usr/sbin/rabbitmqctl cluster_status|sed -n '2p'| perl -pe 's/.*running_nodes\,\[(.*)\]\}.*/$1/g')
 
 ARRAY_LIST_NODES=$(echo $LIST_NODES | tr "," "\n"| tr "\'" "\ ")
 FIRST_ELEMENT=1


### PR DESCRIPTION
1)fix 1: change sed -n '3p' to sed -n '2p'
Command cluster_status returns 3 lines. 4 was expected 
Ex:
/usr/sbin/rabbitmqctl cluster_status
Cluster status of node rabbit@storage ...
[{nodes,[{disc,[rabbit@storage]}]},{running_nodes,[rabbit@storage]}]
...done.

2) I changed that:
sed -n '/running_nodes,[._]},/p' | sed  -r 's/[|]|{|}|running_nodes,//g')
on this:
perl -pe 's/._running_nodes\,[(._)]}._/$1/g')
It's more easy and flexibly
